### PR TITLE
GdalReader Refactor

### DIFF
--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" test  || { exit 1; }
+./sbt -J-Xmx2G "++$TRAVIS_SCALA_VERSION" \
+  "project gdal" test \
+  "project gdal-etl" test || { exit 1; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:8u151
 
-### GDAL 2.2.3 ###
+### GDAL 2.3.0 ###
 ENV ROOTDIR /usr/local/
-ENV GDAL_VERSION 2.2.3
+ENV GDAL_VERSION 2.3.0
 ENV OPENJPEG_VERSION 2.2.0
 
 # Load assets
@@ -82,4 +82,3 @@ RUN \
 
 # Output version and capabilities by default.
 CMD gdalinfo --version && gdalinfo --formats && ogrinfo --formats
-

--- a/gdal/src/main/scala/geotrellis/gdal/GdalReader.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GdalReader.scala
@@ -17,39 +17,171 @@
 package geotrellis.gdal
 
 import geotrellis.raster._
-import geotrellis.vector.Extent
+
+import spire.syntax.cfor._
+import org.gdal.gdal.Dataset
+import org.gdal.gdal.gdal
+import org.gdal.gdalconst.gdalconstConstants
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+
+case class GdalReader(rasterDataSet: RasterDataSet) {
+  private lazy val dataset: Dataset = rasterDataSet.ds
+
+  def read(
+    gridBounds: GridBounds = GridBounds(0, 0, rasterDataSet.cols - 1, rasterDataSet.rows - 1),
+    bands: Seq[Int] = 0 until rasterDataSet.bandCount,
+    noDataValue: Option[Double] = rasterDataSet.noDataValue
+  ): Raster[MultibandTile] = {
+    // NOTE: Bands are not 0-base indexed, so we must add 1// NOTE: Bands are not 0-base indexed, so we must add 1
+    val baseBand = dataset.GetRasterBand(1)
+
+    val bandCount = bands.size
+    val indexBand = bands.zipWithIndex.map { case (v, i) => (i, v) }.toMap
+
+    // setting buffer properties
+    val pixelCount = rasterDataSet.cols * rasterDataSet.rows
+    // sampleFormat
+    val bufferType = baseBand.getDataType
+    // samples per pixel
+    val samplesPerPixel = dataset.getRasterCount
+    // bits per sample
+    val typeSizeInBits = gdal.GetDataTypeSize(bufferType)
+    val typeSizeInBytes = gdal.GetDataTypeSize(bufferType) / 8
+    val bufferSize = bandCount * pixelCount * typeSizeInBytes
+
+    val multibandTile =
+      /** TODO: think about how to handle UByte case **/
+      if (bufferType == gdalconstConstants.GDT_Byte) {
+        // in the byte case we can strictly use
+        val bandsDataArray = Array.ofDim[Array[Byte]](bandCount)
+        cfor(0)(_ < bandCount, _ + 1) { i =>
+          val rBand = dataset.GetRasterBand(indexBand(i) + 1)
+          val dataBuffer = new Array[Byte](bufferSize.toInt)
+          val returnVal = rBand.ReadRaster(
+            gridBounds.colMin,
+            gridBounds.rowMin,
+            gridBounds.width,
+            gridBounds.height,
+            gridBounds.width,
+            gridBounds.height,
+            bufferType,
+            dataBuffer
+          )
+
+          if(returnVal != gdalconstConstants.CE_None)
+            throw new Exception("An error happened during the GDAL Read.")
+
+          bandsDataArray(i) = dataBuffer
+        }
+
+        if(typeSizeInBits == 1) {
+          MultibandTile(bandsDataArray.map { b => BitArrayTile(b, gridBounds.width, gridBounds.height) })
+        } else {
+          val ct = noDataValue match {
+            case Some(nd) => ByteUserDefinedNoDataCellType(nd.toByte)
+            case _ => ByteCellType
+          }
+          MultibandTile(bandsDataArray.map { b => ByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
+        }
+        } else {
+          // for these types we need buffers
+          val bandsDataBuffer = Array.ofDim[ByteBuffer](bandCount)
+          cfor(0)(_ < bandCount, _ + 1) { i =>
+            val rBand = dataset.GetRasterBand(indexBand(i) + 1)
+            val dataBuffer = new Array[Byte](bufferSize.toInt)
+            val returnVal = rBand.ReadRaster(
+              gridBounds.colMin,
+              gridBounds.rowMin,
+              gridBounds.width,
+              gridBounds.height,
+              gridBounds.width,
+              gridBounds.height,
+              bufferType,
+              dataBuffer
+            )
+
+            if(returnVal != gdalconstConstants.CE_None)
+              throw new Exception("An error happened during the GDAL Read.")
+
+            bandsDataBuffer(i) = ByteBuffer.wrap(dataBuffer,0, dataBuffer.length)
+          }
+
+          if (bufferType == gdalconstConstants.GDT_Int16 || bufferType == gdalconstConstants.GDT_UInt16) {
+            val shorts = new Array[Array[Short]](bandCount)
+            cfor(0)(_ < bandCount, _ + 1) { i =>
+              shorts(i) = new Array[Short](pixelCount)
+              bandsDataBuffer(i).order(ByteOrder.nativeOrder)
+              bandsDataBuffer(i).asShortBuffer().get(shorts(i), 0, pixelCount)
+            }
+
+            if (bufferType == gdalconstConstants.GDT_Int16) {
+              val ct = noDataValue match {
+                case Some(nd) => ShortUserDefinedNoDataCellType(nd.toShort)
+                case _ => ShortConstantNoDataCellType
+              }
+              MultibandTile(shorts.map(ShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
+            } else {
+              val ct = noDataValue match {
+                case Some(nd) => UShortUserDefinedNoDataCellType(nd.toShort)
+                case _ => UShortConstantNoDataCellType
+              }
+              MultibandTile(shorts.map(UShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
+            }
+            } else if (bufferType == gdalconstConstants.GDT_Int32 || bufferType == gdalconstConstants.GDT_UInt32) {
+              val ct = noDataValue match {
+                case Some(nd) => IntUserDefinedNoDataCellType(nd.toInt)
+                case _ => IntConstantNoDataCellType
+              }
+
+              val ints = new Array[Array[Int]](bandCount)
+              cfor(0)(_ < bandCount, _ + 1) { i =>
+                ints(i) = new Array[Int](pixelCount)
+                bandsDataBuffer(i).order(ByteOrder.nativeOrder)
+                bandsDataBuffer(i).asIntBuffer().get(ints(i), 0, pixelCount)
+              }
+
+              MultibandTile(ints.map(IntArrayTile(_, gridBounds.width, gridBounds.height, ct)))
+            } else if (bufferType == gdalconstConstants.GDT_Float32) {
+              val ct = noDataValue match {
+                case Some(nd) => FloatUserDefinedNoDataCellType(nd.toFloat)
+                case _ => FloatConstantNoDataCellType
+              }
+
+              val floats = new Array[Array[Float]](bandCount)
+              cfor(0)(_ < bandCount, _ + 1) { i =>
+                floats(i) = new Array[Float](pixelCount)
+                bandsDataBuffer(i).order(ByteOrder.nativeOrder)
+                bandsDataBuffer(i).asFloatBuffer().get(floats(i), 0, pixelCount)
+              }
+
+              MultibandTile(floats.map(FloatArrayTile(_, gridBounds.width, gridBounds.height, ct)))
+            } else if (bufferType == gdalconstConstants.GDT_Float64) {
+              val ct = noDataValue match {
+                case Some(nd) => DoubleUserDefinedNoDataCellType(nd)
+                case _ => DoubleConstantNoDataCellType
+              }
+
+              val doubles = new Array[Array[Double]](bandCount)
+              cfor(0)(_ < bandCount, _ + 1) { i =>
+                doubles(i) = new Array[Double](pixelCount)
+                bandsDataBuffer(i).order(ByteOrder.nativeOrder)
+                bandsDataBuffer(i).asDoubleBuffer().get(doubles(i), 0, pixelCount)
+              }
+
+              MultibandTile(doubles.map(DoubleArrayTile(_, gridBounds.width, gridBounds.height, ct)))
+            } else
+              throw new Exception(s"The specified data type is actually unsupported: $bufferType")
+        }
+
+    Raster(multibandTile, rasterDataSet.extent)
+  }
+}
+
 
 object GdalReader {
-
-  /** This function reads a single band of a GDAL-recognized raster format
-    *
-    * @param path The path GDAL will attempt to read at
-    * @param band The band number (1 indexed) to be read
-    * @return (Tile, RasterExtent) The specified band as a tile and its extent as
-    *                              a RasterExtent
-    */
-  def read(path: String, band: Int = 1): (Tile, RasterExtent) = {
-    val gdalRaster: RasterDataSet = Gdal.open(path)
-
-    try {
-      val extent = Extent(
-        gdalRaster.xmin,
-        gdalRaster.ymin,
-        gdalRaster.xmax,
-        gdalRaster.ymax
-      )
-      val (lcols, lrows) = (gdalRaster.cols, gdalRaster.rows)
-
-      if(lcols * lrows > Int.MaxValue)
-        sys.error(s"Cannot read this raster, cols * rows exceeds maximum array index ($lcols * $lrows)")
-
-      val (cols, rows) = (lcols.toInt, lrows.toInt)
-
-      val rasterExtent = RasterExtent(extent, cols, rows)
-
-      (gdalRaster.bands(band - 1).toTile, rasterExtent)
-    } finally {
-      gdalRaster.close
-    }
-  }
+  def apply(path: String): GdalReader =
+    GdalReader(Gdal.open(path))
 }

--- a/gdal/src/main/scala/geotrellis/gdal/RasterBand.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/RasterBand.scala
@@ -35,7 +35,8 @@ class RasterBand(band: Band, cols: Int, rows: Int) {
   lazy val noDataValue: Option[Double] = {
     val arr = Array.ofDim[java.lang.Double](1)
     band.GetNoDataValue(arr)
-    Option(arr(0))
+
+    arr.headOption.flatMap(Option(_)).map(_.doubleValue)
   }
 
   lazy val rasterType: GdalDataType =

--- a/gdal/src/test/scala/geotrellis/gdal/GdalReaderSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/GdalReaderSpec.scala
@@ -22,7 +22,10 @@ class GdalReaderSpec extends FunSpec
     ifGdalInstalled {
       it("should match one read with GeoTools") {
         println("Reading with GDAL...")
-        val (gdRaster, RasterExtent(gdExt, _, _, _, _)) = GdalReader.read(path)
+        val reader = GdalReader(path)
+        val raster = reader.read()
+        val gdRaster = raster.tile.band(0)
+        val gdExt = raster.extent
         println("Reading with GeoTools....")
         val Raster(gtRaster, gtExt) = SinglebandGeoTiff(path).raster
         println("Done.")
@@ -60,12 +63,15 @@ class GdalReaderSpec extends FunSpec
   describe("reading a JPEG2000") {
     ifGdalWithJpeg2000Installed {
       val lengthExpected = 100
-      type TypeExpected = IntCells
+      type TypeExpected = UShortCells
       val jpeg2000Path = "src/test/resources/data/jpeg2000-test-files/testJpeg2000.jp2"
 
       it("should read a JPEG2000 from a file") {
 
-        val (tile: Tile, extent: RasterExtent) = GdalReader.read(jpeg2000Path)
+        val reader = GdalReader(jpeg2000Path)
+        val raster = reader.read()
+        val tile = raster.tile
+        val extent = raster.rasterExtent
 
         extent.cols should be (lengthExpected)
         extent.rows should be (lengthExpected)

--- a/gdal/src/test/scala/geotrellis/gdal/IngestSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/IngestSpec.scala
@@ -43,19 +43,20 @@ class IngestSpec extends FunSpec
         SpaceTimeKey(SpatialKey(0,0),TemporalKey(ZonedDateTime.parse("2006-03-16T12:00:00.000Z")))
       )
 
+      val resourcesPath = "src/test/resources"
+
       it("should ingest time-band NetCDF") {
-        val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
+        val source = sc.netCdfRDD(new Path(resourcesPath, "ipcc-access1-tasmin.nc"))
         Ingest[TemporalProjectedExtent, SpaceTimeKey](source, LatLng, FloatingLayoutScheme(256)){ (rdd, level) =>
           val ingestKeys = rdd.keys.collect()
           info(ingestKeys.toList.toString)
           // Ingest uses a tileSize of 512x512, so we have less tiles
-          ingestKeys should contain theSameElementsAs
-            expectedKeys.filterNot(stk => stk.spatialKey.col == 2 || stk.spatialKey.row == 1)
+          ingestKeys should contain theSameElementsAs expectedKeys
         }
       }
 
       it("should ingest time-band NetCDF in stages") {
-        val source = sc.netCdfRDD(new Path(inputHome, "ipcc-access1-tasmin.nc"))
+        val source = sc.netCdfRDD(new Path(resourcesPath, "ipcc-access1-tasmin.nc"))
         val (zoom, rmd) = source.collectMetadata[SpaceTimeKey](LatLng, FloatingLayoutScheme(256))
         val tiled = source.cutTiles[SpaceTimeKey](rmd)
         val ingestKeys = tiled.keys.collect()

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -18,7 +18,7 @@ object Version {
   val geotrellisGdal  = "0.12.0" + Environment.versionSuffix
   val scala           = "2.11.12"
   val geotrellis      = "1.2.0"
-  val gdal            = "2.2.1"
+  val gdal            = "2.3.0"
   lazy val hadoop     = Environment.hadoopVersion
   lazy val spark      = Environment.sparkVersion
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,4 +5,4 @@ docker run \
   -v $(pwd)/src:/root/src \
   -v ~/.ivy2:/root/.ivy2 \
   geotrellis/gdal-test \
-  cd ~ & sbt test
+  cd ~ & sbt "project gdal" test & sbt "project gdal-etl" test


### PR DESCRIPTION
This PR refactors `GdalReader` so that it uses the logic from `geotrellis.contrib.vlm.gdal.GDALRasterReader`. In addition, the GDAL version is bumped to 2.3.0