### PR TITLE
bintrayRepository Change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val commonSettings = Seq(
     "-feature"
   ),
   bintrayOrganization := Some("azavea"),
-  bintrayRepository := "maven",
+  bintrayRepository := "geotrellis",
   bintrayVcsUrl := Some("https://github.com/geotrellis/geotrellis-gdal.git"),
   homepage := Some(url("https://github.com/geotrellis/geotrellis-gdal")),
   publishMavenStyle := true,


### PR DESCRIPTION
This PR changes the `bintrayRepository` that `geotrellis-gdal` is published to from `maven` to `geotrellis`.