### PR TITLE
Passing in URIs to Gdal and GdalReader

### DIFF
--- a/gdal/src/main/scala/geotrellis/gdal/Gdal.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/Gdal.scala
@@ -22,6 +22,8 @@ import org.gdal.gdal.gdal
 import org.gdal.gdal.Dataset
 import org.gdal.gdalconst.gdalconstConstants
 
+import java.net.URI
+
 
 class GdalException(code: Int, msg: String)
     extends RuntimeException(s"GDAL ERROR $code: $msg")
@@ -34,8 +36,11 @@ object GdalException {
 object Gdal {
   gdal.AllRegister()
 
-  def open(path: String): RasterDataSet = {
-    val ds = gdal.Open(path, gdalconstConstants.GA_ReadOnly)
+  def open(path: String): RasterDataSet =
+    open(new URI(path))
+
+  def open(uri: URI): RasterDataSet = {
+    val ds = gdal.Open(URIFormatter(uri), gdalconstConstants.GA_ReadOnly)
     if(ds == null) {
       throw GdalException.lastError()
     }
@@ -55,5 +60,5 @@ object Gdal {
       case Min => "min"
       case Median => "med"
       case _ => throw new Exception(s"Could not find equivalent GDALResampleMethod for: $method")
-}
+    }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GdalReader.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GdalReader.scala
@@ -24,6 +24,7 @@ import org.gdal.gdal.Dataset
 import org.gdal.gdal.gdal
 import org.gdal.gdalconst.gdalconstConstants
 
+import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -189,4 +190,7 @@ case class GdalReader(rasterDataSet: RasterDataSet) {
 object GdalReader {
   def apply(path: String): GdalReader =
     GdalReader(Gdal.open(path))
+
+  def apply(uri: URI): GdalReader =
+    GdalReader(Gdal.open(uri))
 }

--- a/gdal/src/main/scala/geotrellis/gdal/URIFormatter.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/URIFormatter.scala
@@ -1,0 +1,91 @@
+package geotrellis.gdal
+
+
+import java.net.URI
+
+
+object Schemes {
+  final val FTP = "ftp"
+  final val HTTP = "http"
+  final val HTTPS = "https"
+
+  final val TAR = "tar"
+  final val ZIP = "zip"
+  final val GZIP = "gzip"
+
+  final val FILE = "file"
+
+  final val S3 = "s3"
+
+  final val GS = "gs"
+
+  final val WASB = "wasb"
+  final val WASBS = "wasbs"
+
+  final val HDFS = "hdfs"
+
+  final val FILE_TYPE_TO_SCHEME =
+    Map(
+      TAR -> TAR,
+      "tgz" -> TAR,
+      ZIP -> ZIP,
+      "kmz" -> ZIP,
+      "ods" -> ZIP,
+      "xlsx" -> ZIP,
+      GZIP -> GZIP
+    )
+}
+
+
+object URIFormatter {
+  import Schemes._
+
+  def apply(path: String): String =
+    apply(new URI(path))
+
+  def apply(uri: URI): String = {
+    // TODO: Support reading a single file from a zip file
+    // ie. reading 1.tiff from a zip: s3://bucket/path/to/my/zipped/data/data.zip/1.tiff
+
+    val path = uri.toString
+
+    // We must first determine if we need to chain file handlers
+    // ie. Reading from a zip file on s3
+    val leadingScheme: String =
+      if (path.contains("."))
+        FILE_TYPE_TO_SCHEME.get(path.substring(path.lastIndexOf(".") + 1)) match {
+          case Some(scheme) => s"/vsi$scheme/"
+          case None => ""
+        }
+      else
+        ""
+
+    val formattedPath: String =
+      uri.getScheme match {
+        case (FTP | HTTP | HTTPS) =>
+          s"/vsicurl/${uri.toString}"
+        case S3 =>
+          s"/vsis3/${uri.getAuthority}${uri.getPath}"
+        case GS =>
+          s"/vsigs/${uri.getAuthority}${uri.getPath}"
+        case (WASB | WASBS) =>
+          val azurePath = {
+            val p = uri.getPath
+
+            if (p.startsWith("/")) p.drop(1) else p
+          }
+
+          s"/vsiaz/${uri.getUserInfo}/$azurePath"
+        case HDFS =>
+          s"/vsihdfs/${uri.toString}"
+        case FILE =>
+          path.split("file://").tail.head
+        case _ =>
+          // If no scheme is found, assume the uri is
+          // a relative path to a file
+          path
+      }
+
+    leadingScheme + formattedPath
+  }
+}

--- a/gdal/src/test/scala/geotrellis/gdal/GdalReaderSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/GdalReaderSpec.scala
@@ -8,6 +8,8 @@ import geotrellis.raster.testkit._
 import geotrellis.raster.io.geotiff._
 import geotrellis.spark.testkit.TestEnvironment
 
+import java.io.File
+
 import org.apache.spark.rdd.RDD
 import org.scalatest._
 
@@ -18,10 +20,11 @@ class GdalReaderSpec extends FunSpec
 {
 
   val path = "src/test/resources/data/slope.tif"
+  val uri = s"file://${new File(path).getAbsolutePath()}"
 
   describe("reading a GeoTiff") {
     ifGdalInstalled {
-      val reader = GdalReader(path)
+      val reader = GdalReader(uri)
       it("should match one read with GeoTools") {
         println("Reading with GDAL...")
         val raster = reader.read()
@@ -78,9 +81,11 @@ class GdalReaderSpec extends FunSpec
       val lengthExpected = 100
       type TypeExpected = UShortCells
       val jpeg2000Path = "src/test/resources/data/jpeg2000-test-files/testJpeg2000.jp2"
+      val jpeg2000URI = s"file://${new File(jpeg2000Path).getAbsolutePath()}"
+
       val jpegTiffPath = "src/test/resources/data/jpeg2000-test-files/jpegTiff.tif"
 
-      val dataset = Gdal.open(jpeg2000Path)
+      val dataset = Gdal.open(jpeg2000URI)
       val jpegReader = GdalReader(dataset)
       val tiffReader = GdalReader(jpegTiffPath)
 

--- a/gdal/src/test/scala/geotrellis/gdal/URIFormatterSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/URIFormatterSpec.scala
@@ -1,0 +1,73 @@
+package geotrellis.gdal
+
+import java.net.URI
+
+import org.scalatest._
+
+
+class URIFormatterSpec extends FunSpec with Matchers {
+  describe("Formatting the given uris") {
+    it("should format - https url") {
+      val filePath = "www.radomdata.com/test-files/file-1.tiff"
+      val url = s"https://$filePath"
+      val expectedPath = s"/vsicurl/$url"
+
+      URIFormatter(url) should be (expectedPath)
+    }
+
+    it("should format - file uri") {
+      val filePath = "/home/jake/Documents/test-files/file-1.tiff"
+      val uri = s"file://$filePath"
+      val expectedPath = filePath
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - chained file uri") {
+      val filePath = "/home/jake/Documents/test-files/files.zip"
+      val uri = s"file://$filePath"
+      val expectedPath = s"/vsizip/$filePath"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - s3 uri") {
+      val filePath = "test-files/nlcd/data/tiff-0.tiff"
+      val uri = s"s3://$filePath"
+      val expectedPath = s"/vsis3/$filePath"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - chained s3 uri") {
+      val filePath = "test-files/nlcd/data/data.gzip"
+      val uri = s"s3://$filePath"
+      val expectedPath = s"/vsigzip//vsis3/$filePath"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - hdfs uri") {
+      val filePath = "test-files/nlcd/data/tiff-0.tiff"
+      val uri = s"hdfs://$filePath"
+      val expectedPath = s"/vsihdfs/$uri"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - Google Cloud Storage uri") {
+      val filePath = "test-files/nlcd/data/tiff-0.tiff"
+      val uri = s"gs://$filePath"
+      val expectedPath = s"/vsigs/$filePath"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+
+    it("should format - Azure uri") {
+      val uri = "wasb://test-files@myaccount.blah.core.net/nlcd/data/tiff-0.tiff"
+      val expectedPath = "/vsiaz/test-files/nlcd/data/tiff-0.tiff"
+
+      URIFormatter(uri) should be (expectedPath)
+    }
+  }
+}


### PR DESCRIPTION
This PR makes it so that users can pass in either paths or `URI`s to `Gdal` and `GdalReader`. This was done by creating the `URIFormatter` object which formats the given path/`URI` in such a way that GDAL can read it.

The backends that are supported with this PR:
- Local Filesystem
- Hdfs
- S3
- Azure
- Google Cloud Storage
- HTTP/HTTPS/FTP

In additions to the supported backends, various compressed filetypes can be read from as well:
- zip
- kmz
- ods
- xlsx
- gzip
- tar
- tgz

**Note:** This PR introduces ways to format a given URI; however, it does nothing with setting permissions. Therefore, it is assumed the user setup their environment such that GDAL can access the needed credentials.