### PR TITLE
Add GDALOptions settings to prevent failures in a multithreaded env

### DIFF
--- a/gdal/src/main/resources/reference.conf
+++ b/gdal/src/main/resources/reference.conf
@@ -1,7 +1,13 @@
-gdal.cache {
-  maximumSize: 1000
-  enableDefaultRemovalListener: true
-  valuesType: Weak
-  enabled: true
-  withShutdownHook: true
+gdal {
+  options {
+    maxDatasetPoolSize: 1
+    vrtSharedSource: false
+  }
+  cache {
+    maximumSize: 100
+    enableDefaultRemovalListener: true
+    valuesType: Weak
+    enabled: true
+    withShutdownHook: true
+  }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDAL.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDAL.scala
@@ -17,16 +17,13 @@
 package geotrellis.gdal
 
 import geotrellis.gdal.cache.LazyCache
-import geotrellis.gdal.config.GDALCacheConfig
-
+import geotrellis.gdal.config.{GDALCacheConfig, GDALOptionsConfig}
 import cats.syntax.foldable._
 import cats.syntax.option._
 import cats.instances.list._
 import cats.instances.either._
-
 import org.gdal.gdalconst.gdalconstConstants
 import com.typesafe.scalalogging.LazyLogging
-
 import java.net.URI
 
 // All of the logic in this file was taken from:
@@ -42,6 +39,9 @@ private [gdal] object GDALException {
 
 object GDAL extends LazyLogging {
   sgdal.AllRegister
+
+  // sets GDALConfig options
+  GDALOptionsConfig.set
 
   def openURI(uri: URI): GDALDataset =
     openPath(VSIPath(uri.toString).vsiPath)

--- a/gdal/src/main/scala/geotrellis/gdal/GDALBand.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALBand.scala
@@ -608,11 +608,6 @@ case class GDALBand(underlying: Band) extends GDALMajorObject {
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
-  }
-
-  override protected def finalize(): Unit = {
-    delete
-    super.finalize()
+    if(underlying != null) underlying.delete
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALColorTable.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALColorTable.scala
@@ -55,11 +55,11 @@ case class GDALColorTable(underlying: ColorTable) extends Cloneable {
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
+    if(underlying != null) underlying.delete
   }
 
   override protected def finalize(): Unit = {
-    delete
+    if(underlying != null) underlying.delete
     super.finalize()
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALDataset.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALDataset.scala
@@ -517,11 +517,11 @@ case class GDALDataset(underlying: Dataset) extends GDALMajorObject {
     }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
+    if(underlying != null) underlying.delete
   }
 
   override def finalize(): Unit = {
-    delete
+    if(underlying != null) underlying.delete
     super.finalize()
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALDriver.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALDriver.scala
@@ -114,11 +114,6 @@ case class GDALDriver(underlying: Driver) extends GDALMajorObject {
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
-  }
-
-  override def finalize(): Unit = {
-    delete
-    super.finalize()
+    if(underlying != null) underlying.delete
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALLayer.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALLayer.scala
@@ -309,11 +309,6 @@ case class GDALLayer(underlying: Layer) {
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
-  }
-
-  override def finalize(): Unit = {
-    delete
-    super.finalize()
+    if(underlying != null) underlying.delete
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALRasterAttributeTable.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALRasterAttributeTable.scala
@@ -98,11 +98,11 @@ case class GDALRasterAttributeTable(underlying: RasterAttributeTable) extends Cl
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
+    if(underlying != null) underlying.delete
   }
 
   override protected def finalize(): Unit = {
-    delete
+    if(underlying != null) underlying.delete
     super.finalize()
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/GDALStyleTable.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALStyleTable.scala
@@ -48,11 +48,11 @@ case class GDALStyleTable(underlying: StyleTable) {
   }
 
   def delete: Unit = AnyRef.synchronized {
-    underlying.delete
+    if(underlying != null) underlying.delete
   }
 
   override protected def finalize(): Unit = {
-    delete
+    if(underlying != null) underlying.delete
     super.finalize()
   }
 }

--- a/gdal/src/main/scala/geotrellis/gdal/config/GDALCacheConfig.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/config/GDALCacheConfig.scala
@@ -53,7 +53,7 @@ case class GDALCacheConfig(
     if(withShutdownHook) Runtime.getRuntime.addShutdownHook(new Thread() { override def run(): Unit = GDAL.cacheCleanUp })
 }
 
-object GDALCacheConfig extends PureConfigSettings{
+object GDALCacheConfig extends PureConfigSettings {
   lazy val conf: GDALCacheConfig = pureconfig.loadConfigOrThrow[GDALCacheConfig]("gdal.cache")
   implicit def gdalCacheConfig(obj: GDALCacheConfig.type): GDALCacheConfig = conf
 }

--- a/gdal/src/main/scala/geotrellis/gdal/config/GDALOptionsConfig.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/config/GDALOptionsConfig.scala
@@ -1,0 +1,14 @@
+package geotrellis.gdal.config
+
+import geotrellis.gdal.sgdal
+
+case class GDALOptionsConfig(maxDatasetPoolSize: Int = 1, vrtSharedSource: Boolean = false) {
+  def setMaxDatasetPoolSize: Unit = sgdal.setConfigOption("GDAL_MAX_DATASET_POOL_SIZE", s"$maxDatasetPoolSize")
+  def setVRTSharedSource: Unit = sgdal.setConfigOption("VRT_SHARED_SOURCE", s"${ if(vrtSharedSource) 1 else 0 }")
+  def set: Unit = { setMaxDatasetPoolSize; setVRTSharedSource }
+}
+
+object GDALOptionsConfig extends PureConfigSettings {
+  lazy val conf: GDALOptionsConfig = pureconfig.loadConfigOrThrow[GDALOptionsConfig]("gdal.options")
+  implicit def gdalOptionsConfig(obj: GDALOptionsConfig.type): GDALOptionsConfig = conf
+}

--- a/gdal/src/test/scala/geotrellis/gdal/GDALReaderSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/GDALReaderSpec.scala
@@ -7,11 +7,7 @@ import geotrellis.raster.io.geotiff._
 
 import org.scalatest._
 
-class GDALReaderSpec extends FunSpec
-  with RasterMatchers
-  with OnlyIfGdalInstalled
-{
-
+class GDALReaderSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
   val path = "gdal/src/test/resources/data/slope.tif"
 
   describe("reading a GeoTiff") {


### PR DESCRIPTION
After investigating GDAL sources, it looks like we probably don't need `synchronized` calls at all.