### PR TITLE
Add GDAL version environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ val firstBand: (Tile, RasterExtent) =
 Note that the `band` parameter specifies the band to be read and turned
 into a tile rather than the number of bands expected.
 
+## GDAL Compatibility Matrix
+
+| `geotrellis-gdal` | GDAL     |
+| ----------------- | -------- |
+| >= v0.17.x        | >= 2.3.3 |

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -19,7 +19,7 @@ object Version {
   val scala           = "2.11.12"
   val crossScala      = Seq(scala, "2.12.8")
   val geotrellis      = "3.0.0-SNAPSHOT"
-  val gdal            = "2.3.3"
+  val gdal            = Properties.envOrElse("GDAL_VERSION", "2.3.3")
   lazy val hadoop     = Properties.envOrElse("SPARK_HADOOP_VERSION", "2.8.5")
   lazy val spark      = Properties.envOrElse("SPARK_VERSION", "2.4.0")
 }


### PR DESCRIPTION
Allow library consumers to define the version of GDAL Java bindings installed in the environment `geotrellis-gdal` intends to be executed in. Also, add the beginnings of a compatibility matrix for `geotrellis-gdal` and GDAL version pairings.

Fixes https://github.com/geotrellis/geotrellis-gdal/issues/37

---

**Testing**

```bash
$ docker run --rm \
  -v $(pwd)/build.sbt:/root/build.sbt \
  -v $(pwd)/project:/root/project \
  -v $(pwd)/gdal:/root/gdal \
  -v $(pwd)/src:/root/src \
  -v $(pwd)/sbt:/root/sbt \
  -w /root \
  -e GDAL_VERSION=2.3.2 \
  quay.io/azavea/openjdk-gdal:2.3.2-slim \
  ./sbt "project gdal" test

...

[info] Run completed in 26 seconds, 109 milliseconds.
[info] Total number of tests run: 47
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 47, failed 0, canceled 0, ignored 3, pending 0
[info] All tests passed.
[success] Total time: 77 s, completed Jan 10, 2019 3:07:22 AM
```