### PR TITLE
Fix CellType derivation

### DIFF
--- a/gdal/src/main/scala/geotrellis/gdal/GDALReader.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALReader.scala
@@ -59,6 +59,10 @@ class GDALReader(val dataset: Dataset) {
     // NOTE: Bands are not 0-base indexed, so we must add 1// NOTE: Bands are not 0-base indexed, so we must add 1
     val baseBand = dataset.GetRasterBand(1)
 
+    // we don't have access to the sampleFormat, but we can calculate MinMax values
+    // would be calculated only to derive UByte cell type
+    lazy val minMax = baseBand.computeRasterMinMax
+
     val bandCount = bands.size
     val indexBand = bands.zipWithIndex.map { case (v, i) => (i, v) }.toMap
 
@@ -72,6 +76,13 @@ class GDALReader(val dataset: Dataset) {
     val typeSizeInBits = gdal.GetDataTypeSize(bufferType)
     val typeSizeInBytes = gdal.GetDataTypeSize(bufferType) / 8
     val bufferSize = bandCount * pixelCount * typeSizeInBytes
+
+    val cellType = GDALUtils.dataTypeToCellType(
+      datatype = bufferType,
+      noDataValue = noDataValue,
+      typeSizeInBits = Some(typeSizeInBits),
+      minMaxValues = minMax
+    )
 
     /** TODO: think about how to handle UByte case **/
     if (bufferType == gdalconstConstants.GDT_Byte) {
@@ -100,11 +111,13 @@ class GDALReader(val dataset: Dataset) {
       if(typeSizeInBits == 1) {
         MultibandTile(bandsDataArray.map { b => BitArrayTile(b, gridBounds.width, gridBounds.height) })
       } else {
-        val ct = noDataValue match {
-          case Some(nd) => ByteUserDefinedNoDataCellType(nd.toByte)
-          case _ => ByteCellType
+        if(cellType.isUnsigned) {
+          val ct = cellType.as[UByteCells with NoDataHandling]
+          MultibandTile(bandsDataArray.map { b => UByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
+        } else {
+          val ct = cellType.as[ByteCells with NoDataHandling]
+          MultibandTile(bandsDataArray.map { b => ByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
         }
-        MultibandTile(bandsDataArray.map { b => ByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
       }
     } else {
       // for these types we need buffers
@@ -138,23 +151,14 @@ class GDALReader(val dataset: Dataset) {
         }
 
         if (bufferType == gdalconstConstants.GDT_Int16) {
-          val ct = noDataValue match {
-            case Some(nd) => ShortUserDefinedNoDataCellType(nd.toShort)
-            case _ => ShortConstantNoDataCellType
-          }
+          val ct = cellType.as[ShortCells with NoDataHandling]
           MultibandTile(shorts.map(ShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
         } else {
-          val ct = noDataValue match {
-            case Some(nd) => UShortUserDefinedNoDataCellType(nd.toShort)
-            case _ => UShortConstantNoDataCellType
-          }
+          val ct = cellType.as[UShortCells with NoDataHandling]
           MultibandTile(shorts.map(UShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
         }
-      } else if (bufferType == gdalconstConstants.GDT_Int32 || bufferType == gdalconstConstants.GDT_UInt32) {
-        val ct = noDataValue match {
-          case Some(nd) => IntUserDefinedNoDataCellType(nd.toInt)
-          case _ => IntConstantNoDataCellType
-        }
+      } else if (bufferType == gdalconstConstants.GDT_Int32) {
+        val ct = cellType.as[IntCells with NoDataHandling]
 
         val ints = new Array[Array[Int]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>
@@ -164,11 +168,8 @@ class GDALReader(val dataset: Dataset) {
         }
 
         MultibandTile(ints.map(IntArrayTile(_, gridBounds.width, gridBounds.height, ct)))
-      } else if (bufferType == gdalconstConstants.GDT_Float32) {
-        val ct = noDataValue match {
-          case Some(nd) => FloatUserDefinedNoDataCellType(nd.toFloat)
-          case _ => FloatConstantNoDataCellType
-        }
+      } else if (bufferType == gdalconstConstants.GDT_UInt32 || bufferType == gdalconstConstants.GDT_Float32) {
+        val ct = cellType.as[FloatCells with NoDataHandling]
 
         val floats = new Array[Array[Float]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>
@@ -179,10 +180,7 @@ class GDALReader(val dataset: Dataset) {
 
         MultibandTile(floats.map(FloatArrayTile(_, gridBounds.width, gridBounds.height, ct)))
       } else if (bufferType == gdalconstConstants.GDT_Float64) {
-        val ct = noDataValue match {
-          case Some(nd) => DoubleUserDefinedNoDataCellType(nd)
-          case _ => DoubleConstantNoDataCellType
-        }
+        val ct = cellType.as[DoubleCells with NoDataHandling]
 
         val doubles = new Array[Array[Double]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>

--- a/gdal/src/main/scala/geotrellis/gdal/GDALReader.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALReader.scala
@@ -112,10 +112,16 @@ class GDALReader(val dataset: Dataset) {
         MultibandTile(bandsDataArray.map { b => BitArrayTile(b, gridBounds.width, gridBounds.height) })
       } else {
         if(cellType.isUnsigned) {
-          val ct = cellType.as[UByteCells with NoDataHandling]
+          val ct = cellType match {
+            case c: UByteCells with NoDataHandling => c
+            case _ => throw new Exception(s"CellType ${cellType} can't be casted to UByte.")
+          }
           MultibandTile(bandsDataArray.map { b => UByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
         } else {
-          val ct = cellType.as[ByteCells with NoDataHandling]
+          val ct = cellType match {
+            case c: ByteCells with NoDataHandling => c
+            case _ => throw new Exception(s"CellType ${cellType} can't be casted to Byte.")
+          }
           MultibandTile(bandsDataArray.map { b => ByteArrayTile(b, gridBounds.width, gridBounds.height, ct) })
         }
       }
@@ -151,14 +157,23 @@ class GDALReader(val dataset: Dataset) {
         }
 
         if (bufferType == gdalconstConstants.GDT_Int16) {
-          val ct = cellType.as[ShortCells with NoDataHandling]
+          val ct = cellType match {
+            case c: ShortCells with NoDataHandling => c
+            case _ => throw new Exception(s"CellType ${cellType} can't be casted to Short.")
+          }
           MultibandTile(shorts.map(ShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
         } else {
-          val ct = cellType.as[UShortCells with NoDataHandling]
+          val ct = cellType match {
+            case c: UShortCells with NoDataHandling => c
+            case _ => throw new Exception(s"CellType ${cellType} can't be casted to UShort.")
+          }
           MultibandTile(shorts.map(UShortArrayTile(_, gridBounds.width, gridBounds.height, ct)))
         }
       } else if (bufferType == gdalconstConstants.GDT_Int32) {
-        val ct = cellType.as[IntCells with NoDataHandling]
+        val ct = cellType match {
+          case c: IntCells with NoDataHandling => c
+          case _ => throw new Exception(s"CellType ${cellType} can't be casted to Int.")
+        }
 
         val ints = new Array[Array[Int]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>
@@ -169,7 +184,10 @@ class GDALReader(val dataset: Dataset) {
 
         MultibandTile(ints.map(IntArrayTile(_, gridBounds.width, gridBounds.height, ct)))
       } else if (bufferType == gdalconstConstants.GDT_UInt32 || bufferType == gdalconstConstants.GDT_Float32) {
-        val ct = cellType.as[FloatCells with NoDataHandling]
+        val ct = cellType match {
+          case c: FloatCells with NoDataHandling => c
+          case _ => throw new Exception(s"CellType ${cellType} can't be casted to Float.")
+        }
 
         val floats = new Array[Array[Float]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>
@@ -180,7 +198,10 @@ class GDALReader(val dataset: Dataset) {
 
         MultibandTile(floats.map(FloatArrayTile(_, gridBounds.width, gridBounds.height, ct)))
       } else if (bufferType == gdalconstConstants.GDT_Float64) {
-        val ct = cellType.as[DoubleCells with NoDataHandling]
+        val ct = cellType match {
+          case c: DoubleCells with NoDataHandling => c
+          case _ => throw new Exception(s"CellType ${cellType} can't be casted to Double.")
+        }
 
         val doubles = new Array[Array[Double]](bandCount)
         cfor(0)(_ < bandCount, _ + 1) { i =>

--- a/gdal/src/main/scala/geotrellis/gdal/GDALUtils.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALUtils.scala
@@ -36,41 +36,68 @@ object GDALUtils {
       case _ => throw new Exception(s"Could not find equivalent GDALResampleMethod for: $method")
     }
 
-  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: Option[Int] = None): CellType =
+  def dataTypeToCellType(datatype: GDALDataType, noDataValue: Option[Double] = None, typeSizeInBits: => Option[Int] = None, minMaxValues: => Option[(Double, Double)] = None): CellType =
     datatype match {
-      case UnknownType | TypeFloat64 =>
-        noDataValue match {
-          case Some(nd) => DoubleUserDefinedNoDataCellType(nd)
-          case _ => DoubleConstantNoDataCellType
-        }
       case TypeByte =>
         typeSizeInBits match {
           case Some(bits) if bits == 1 => BitCellType
           case _ =>
-            noDataValue match {
-              case Some(nd) => ByteUserDefinedNoDataCellType(nd.toByte)
-              case _ => ByteCellType
+            minMaxValues match {
+              case Some((mi, ma)) if (mi.toInt >= 0 && mi <= 255) && (ma.toInt >= 0 && ma <= 255) =>
+                noDataValue match {
+                  case Some(nd) if nd.toInt > 0 && nd <= 255 => UByteUserDefinedNoDataCellType(nd.toByte)
+                  case Some(nd) if nd.toInt == 0 => UByteConstantNoDataCellType
+                  case _ => UByteCellType
+                }
+              case _ =>
+                noDataValue match {
+                  case Some(nd) if nd.toInt > Byte.MinValue.toInt && nd <= Byte.MaxValue.toInt => ByteUserDefinedNoDataCellType(nd.toByte)
+                  case Some(nd) if nd.toInt == Byte.MinValue.toInt => ByteConstantNoDataCellType
+                  case _ => ByteCellType
+                }
             }
         }
       case TypeUInt16 =>
         noDataValue match {
-          case Some(nd) => UShortUserDefinedNoDataCellType(nd.toShort)
-          case _ => UShortConstantNoDataCellType
+          case Some(nd) if nd.toInt > 0 && nd <= 65535 => UShortUserDefinedNoDataCellType(nd.toShort)
+          case Some(nd) if nd.toInt == 0 => UShortConstantNoDataCellType
+          case _ => UShortCellType
         }
       case TypeInt16 =>
         noDataValue match {
-          case Some(nd) => ShortUserDefinedNoDataCellType(nd.toShort)
-          case _ => ShortConstantNoDataCellType
+          case Some(nd) if nd > Short.MinValue.toDouble && nd <= Short.MaxValue.toDouble => ShortUserDefinedNoDataCellType(nd.toShort)
+          case Some(nd) if nd == Short.MinValue.toDouble => ShortConstantNoDataCellType
+          case _ => ShortCellType
         }
-      case TypeUInt32 | TypeInt32 =>
+      case TypeUInt32 =>
         noDataValue match {
-          case Some(nd) => IntUserDefinedNoDataCellType(nd.toInt)
-          case _ => IntConstantNoDataCellType
+          case Some(nd) if nd.toLong > 0l && nd.toLong <= 4294967295l => FloatUserDefinedNoDataCellType(nd.toFloat)
+          case Some(nd) if nd.toLong == 0l => FloatConstantNoDataCellType
+          case _ => FloatCellType
+        }
+      case TypeInt32 =>
+        noDataValue match {
+          case Some(nd) if nd.toInt > Int.MinValue && nd.toInt <= Int.MaxValue => IntUserDefinedNoDataCellType(nd.toInt)
+          case Some(nd) if nd.toInt == Int.MinValue => IntConstantNoDataCellType
+          case _ => IntCellType
         }
       case TypeFloat32 =>
         noDataValue match {
-          case Some(nd) => FloatUserDefinedNoDataCellType(nd.toFloat)
-          case _ => FloatConstantNoDataCellType
+          case Some(nd) if isData(nd) && Float.MinValue.toDouble <= nd && Float.MaxValue.toDouble >= nd => FloatUserDefinedNoDataCellType(nd.toFloat)
+          case Some(nd) => FloatConstantNoDataCellType
+          case _ => FloatCellType
+        }
+      case TypeFloat64 =>
+        noDataValue match {
+          case Some(nd) if isData(nd) => DoubleUserDefinedNoDataCellType(nd)
+          case Some(nd) => FloatConstantNoDataCellType
+          case _ => FloatCellType
+        }
+      case UnknownType =>
+        noDataValue match {
+          case Some(nd) if java.lang.Double.isFinite(nd) => DoubleUserDefinedNoDataCellType(nd)
+          case Some(nd) => DoubleConstantNoDataCellType
+          case _ => DoubleCellType
         }
       case TypeCInt16 | TypeCInt32 | TypeCFloat32 | TypeCFloat64 =>
         throw new UnsupportedOperationException("Complex datatypes are not supported")

--- a/gdal/src/main/scala/geotrellis/gdal/package.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/package.scala
@@ -135,7 +135,5 @@ package object gdal extends Serializable {
         case _ => false
       }
     }
-
-    def as[T <: CellType]: T = self.asInstanceOf[T]
   }
 }

--- a/gdal/src/test/scala/geotrellis/gdal/GDALReaderSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/GDALReaderSpec.scala
@@ -5,9 +5,10 @@ import geotrellis.raster._
 import geotrellis.raster.testkit._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
-
 import org.scalatest._
 import java.io.File
+
+import geotrellis.vector.Extent
 
 class GDALReaderSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
   val path = s"${new File("").getAbsolutePath()}/src/test/resources/data/slope.tif"
@@ -16,10 +17,21 @@ class GDALReaderSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalle
     ifGdalInstalled {
       it("should read full raster correct") {
         val filePath = s"${new File("").getAbsolutePath()}/src/test/resources/data/aspect-tiled.tif"
-        println(filePath)
         val gdalTile = GDALReader(filePath).read().toArrayTile
         val gtTile   = GeoTiffReader.readMultiband(filePath).tile.toArrayTile
-        
+
+        gdalTile.cellType shouldBe gtTile.cellType
+        assertEqual(gdalTile, gtTile)
+      }
+
+      it("should read a raster with bad nodata value set correct") {
+        val filePath = s"${new File("").getAbsolutePath()}/src/test/resources/data/badnodata.tif"
+        // using a small extent to make tests work faster
+        val ext = Extent(680138.59203, 4904905.667, 680189.7, 4904955.9)
+        val gdalTile = GDALReader(filePath).read(ext).toArrayTile
+        val gtTile   = GeoTiffReader.readMultiband(filePath, ext).tile.toArrayTile
+
+        gdalTile.cellType shouldBe gtTile.cellType
         assertEqual(gdalTile, gtTile)
       }
 


### PR DESCRIPTION
This PR fixes inappropriate `GDALCellTypes` conversion into `GeoTrellisCellTypes`.

Fixes: https://github.com/raster-foundry/raster-foundry/issues/4442