### PR TITLE
gdal.Warp cleanup

### DIFF
--- a/gdal/src/main/scala/geotrellis/gdal/GDAL.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDAL.scala
@@ -40,9 +40,6 @@ object GDAL extends LazyLogging {
   // NEL, Dataset is the result VRT and List[Dataset] is a list of parent Datasets
   type HDataset = (Dataset, List[Dataset])
 
-  // Store temporary VRT XML files in this temporary directory
-  val tmpDir: String = System.getProperty("java.io.tmpdir")
-
   gdal.AllRegister
 
   // sets GDALConfig options
@@ -71,18 +68,17 @@ object GDAL extends LazyLogging {
 
   // parentWarpOptions is a tuple of a path to the initial dataset and a list of previous transformations
   // it is required to calculate a proper cache key
-  private def warp(dest: Option[String], baseDatasets: Array[Dataset], warpOptions: GDALWarpOptions, parentWarpOptions: Option[(String, List[GDALWarpOptions])]): Dataset = AnyRef.synchronized {
+  private def warp(dest: String, baseDatasets: Array[Dataset], warpOptions: GDALWarpOptions, parentWarpOptions: Option[(String, List[GDALWarpOptions])]): Dataset = AnyRef.synchronized {
     // current warp key
     val key = s"${parentWarpOptions.name}${warpOptions.name}".md5
-    val destString = dest.getOrElse(s"$tmpDir$key.vrt")
     // put parent into the strong cache
-    lazy val getDS = gdal.Warp(destString, baseDatasets, warpOptions.toWarpOptions)
+    lazy val getDS = gdal.Warp(dest, baseDatasets, warpOptions.toWarpOptions)
     val ds = cache.get(key.md5, _ => getDS)
     if(ds == null) throw GDALException.lastError()
     ds
   }
 
-  def warp(dest: Option[String], baseDataset: Dataset, warpOptions: GDALWarpOptions, parentWarpOptions: Option[(String, List[GDALWarpOptions])]): Dataset =
+  def warp(dest: String, baseDataset: Dataset, warpOptions: GDALWarpOptions, parentWarpOptions: Option[(String, List[GDALWarpOptions])]): Dataset =
     warp(dest, Array(baseDataset), warpOptions, parentWarpOptions)
 
   def fromGDALWarpOptions(uri: String, list: List[GDALWarpOptions]): Dataset =
@@ -108,7 +104,7 @@ object GDAL extends LazyLogging {
             case None =>
               if (idx == 0) {
                 Left(Option(list.zipWithIndex.foldLeft(baseDataset -> List[Dataset](baseDataset)) { case ((ds, dsh), (ops, index)) =>
-                  val res = warp(if(persistent) None else "".some, ds, ops, (uri, list.take(index)).some)
+                  val res = warp("", ds, ops, (uri, list.take(index)).some)
                   val history = if(index != list.length - 1) dsh :+ res else dsh
                   (res, history)
                 }))
@@ -124,7 +120,7 @@ object GDAL extends LazyLogging {
                   // build new Datasets that are not in cache
                   val (dataset, newHistory): HDataset =
                     list.drop(idx).foldLeft(base -> List[Dataset](base)) { case ((ds, dsh), ops) =>
-                      val res = warp(if(persistent) None else "".some, ds, ops, (uri, list.drop(idx)).some)
+                      val res = warp("", ds, ops, (uri, list.drop(idx)).some)
                       (res, dsh :+ res)
                     }
 

--- a/gdal/src/main/scala/geotrellis/gdal/GDALWarpOptions.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/GDALWarpOptions.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConverters._
   */
 case class GDALWarpOptions(
   /** -of, Select the output format. The default is GeoTIFF (GTiff). Use the short format name. */
-  outputFormat: Option[String] = Some("VRT"),
+  outputFormat: Option[String] = Some("MEM"),
   /** -r, Resampling method to use, visit https://www.gdal.org/gdalwarp.html for details. */
   resampleMethod: Option[ResampleMethod] = None,
   /** -et, error threshold for transformation approximation */

--- a/gdal/src/main/scala/geotrellis/gdal/config/GDALOptionsConfig.scala
+++ b/gdal/src/main/scala/geotrellis/gdal/config/GDALOptionsConfig.scala
@@ -18,7 +18,7 @@ package geotrellis.gdal.config
 
 import org.gdal.gdal.gdal
 
-case class GDALOptionsConfig(maxDatasetPoolSize: Int = 1, vrtSharedSource: Boolean = false, cplDebug: String = "OFF", useExceptions: Boolean = true) {
+case class GDALOptionsConfig(maxDatasetPoolSize: Int = 100, vrtSharedSource: Boolean = false, cplDebug: String = "OFF", useExceptions: Boolean = true) {
   def setMaxDatasetPoolSize: Unit = gdal.SetConfigOption("GDAL_MAX_DATASET_POOL_SIZE", s"$maxDatasetPoolSize")
   def setVRTSharedSource: Unit = gdal.SetConfigOption("VRT_SHARED_SOURCE", s"${ if(vrtSharedSource) 1 else 0 }")
   def setCPLDebugMode: Unit = gdal.SetConfigOption("CPL_DEBUG", cplDebug)

--- a/gdal/src/test/scala/geotrellis/gdal/DatasetSpec.scala
+++ b/gdal/src/test/scala/geotrellis/gdal/DatasetSpec.scala
@@ -33,7 +33,7 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
 
   val reprojectOptions =
     GDALWarpOptions(
-      Some("VRT"),
+      Some("MEM"),
       Some(NearestNeighbor),
       Some(0.125),
       Some(CellSize(19.109257071294063, 19.109257071294063)),
@@ -51,7 +51,7 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
 
   val resampleOptions =
     GDALWarpOptions(
-      Some("VRT"),
+      Some("MEM"),
       Some(NearestNeighbor),
       None,
       Some(CellSize(19.109257071294063, 19.109257071294063)),
@@ -67,8 +67,8 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
       false, None, false, false, Nil, None, None, None, None, None, false, false, false, None, false, Nil, Nil, Nil, None
     )
 
-  def dsreproject(dataset: Dataset): Dataset = GDAL.warp(None, dataset, reprojectOptions, None)
-  def dsresample(dataset: Dataset, uri: Option[String]): Dataset = GDAL.warp(None, dataset, resampleOptions, uri.map(str => str -> List(reprojectOptions)))
+  def dsreproject(dataset: Dataset): Dataset = GDAL.warp("", dataset, reprojectOptions, None)
+  def dsresample(dataset: Dataset, uri: Option[String]): Dataset = GDAL.warp("", dataset, resampleOptions, uri.map(str => str -> List(reprojectOptions)))
 
   def parellSpec(n: Int = 1000)(implicit cs: ContextShift[IO]): List[(Dataset, Dataset, Dataset)] = {
     println(java.lang.Thread.activeCount())
@@ -155,7 +155,7 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
 
     it("should build and keep history, two Datasets are stored in the Dataset pool case") {
       val baseDataset = GDAL.open(filePath)
-      val firstVRT = GDAL.warp(None, baseDataset, GDALWarpOptions(), Some(filePath, Nil))
+      val firstVRT = GDAL.warp("", baseDataset, GDALWarpOptions(), Some(filePath, Nil))
       val vrtPlan = List(GDALWarpOptions(), reprojectOptions, resampleOptions)
 
       val (result, history) = GDAL.fromGDALWarpOptionsH(filePath, vrtPlan, baseDataset, persistent = false)
@@ -168,8 +168,8 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
 
     it("should build and keep history, three Datasets are stored in the Dataset pool case") {
       val baseDataset = GDAL.open(filePath)
-      val firstVRT = GDAL.warp(None, baseDataset, GDALWarpOptions(), Some(filePath, Nil))
-      val secondVRT = GDAL.warp(None, firstVRT, reprojectOptions, Some(filePath, List(GDALWarpOptions())))
+      val firstVRT = GDAL.warp("", baseDataset, GDALWarpOptions(), Some(filePath, Nil))
+      val secondVRT = GDAL.warp("", firstVRT, reprojectOptions, Some(filePath, List(GDALWarpOptions())))
 
       val vrtPlan = List(GDALWarpOptions(), reprojectOptions, resampleOptions)
 
@@ -184,9 +184,9 @@ class DatasetSpec extends FunSpec with RasterMatchers with OnlyIfGdalInstalled {
 
     it("should build and keep history, four Datasets are stored in the Dataset pool case") {
       val baseDataset = GDAL.open(filePath)
-      val firstVRT = GDAL.warp(None, baseDataset, GDALWarpOptions(), Some(filePath, Nil))
-      val secondVRT = GDAL.warp(None, firstVRT, reprojectOptions, Some(filePath, List(GDALWarpOptions())))
-      val thirdVRT = GDAL.warp(None, secondVRT, resampleOptions, Some(filePath, List(GDALWarpOptions(), reprojectOptions)))
+      val firstVRT = GDAL.warp("", baseDataset, GDALWarpOptions(), Some(filePath, Nil))
+      val secondVRT = GDAL.warp("", firstVRT, reprojectOptions, Some(filePath, List(GDALWarpOptions())))
+      val thirdVRT = GDAL.warp("", secondVRT, resampleOptions, Some(filePath, List(GDALWarpOptions(), reprojectOptions)))
       val vrtPlan = List(GDALWarpOptions(), reprojectOptions, resampleOptions, resampleOptions)
 
       val (result, history) = GDAL.fromGDALWarpOptionsH(filePath, vrtPlan, baseDataset, persistent = false)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -19,7 +19,7 @@ import scala.util.Properties
 object Version {
   val scala           = "2.11.12"
   val crossScala      = Seq(scala, "2.12.8")
-  val geotrellis      = "3.0.0-SNAPSHOT"
+  val geotrellis      = "2.2.0"
   val gdal            = Properties.envOrElse("GDAL_VERSION", "2.3.3")
   lazy val hadoop     = Properties.envOrElse("SPARK_HADOOP_VERSION", "2.8.5")
   lazy val spark      = Properties.envOrElse("SPARK_VERSION", "2.4.0")


### PR DESCRIPTION
* Make `gdal.Warp` objects anonymous again
* Use `MEM` as an outputFormat of all `Warp` Datasets

The reason it's a parameter to check would it make any sense to use `MEM` format instead of `VRT`: https://github.com/OSGeo/gdal/blob/8528a635e815557ca4a7d26054602f0fe22cc408/autotest/utilities/test_gdalwarp_lib.py

**WARN:** Let's merge it only after gatling tests