### PR TITLE
Fix default SCALA_VERSION value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,10 @@ services:
     environment:
       - BINTRAY_USER=$BINTRAY_USER
       - BINTRAY_PASS=$BINTRAY_PASS
-      - SCALA_VERSION=${SCALA_VERSION:-2.11.12}
     volumes:
       - ${TRAVIS_BUILD_DIR:-./}:/opt/geotrellis-gdal
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
     working_dir: /opt/geotrellis-gdal
-    entrypoint: ./sbt "++$SCALA_VERSION"
+    entrypoint: ./sbt "++${SCALA_VERSION:-2.11.12}"


### PR DESCRIPTION
## Overview

Before, the default value for `$SCALA_VERSION` was being threaded inside the container, but wasn't accessible in `entrypoint`.

Fixes #51 

## Testing Instructions

```bash
> rbreslow@maiden geotrellis-gdal (feature/jrb/make-test-script-work) $ ./scripts/test
WARNING: The BINTRAY_USER variable is not set. Defaulting to a blank string.
WARNING: The BINTRAY_PASS variable is not set. Defaulting to a blank string.
[info] Loading settings for project global-plugins from idea.sbt ...
[info] Loading global plugins from /root/.sbt/1.0/plugins
[info] Loading settings for project geotrellis-gdal-build from plugins.sbt ...
[info] Loading project definition from /opt/geotrellis-gdal/project
[info] Loading settings for project root from build.sbt ...
[info] Set current project to root (in build file:/opt/geotrellis-gdal/)
[info] Setting Scala version to 2.11.12 on 4 projects.
[info] Reapplying settings...
[info] Set current project to root (in build file:/opt/geotrellis-gdal/)
...
[info] All tests passed.
[success] Total time: 45 s, completed Jan 29, 2019 4:17:06 PM
[success] Total time: 13 s, completed Jan 29, 2019 4:17:19 PM
> rbreslow@maiden geotrellis-gdal (feature/jrb/make-test-script-work) $
```